### PR TITLE
feat: Add model path argument to main_linprobe.py and update SLURM script

### DIFF
--- a/dev/run_on_hpc/run_linprobe.sh
+++ b/dev/run_on_hpc/run_linprobe.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-#SBATCH --job-name=eval_lin_probe 
-#SBATCH --output=logs/eval_lin_probe-%j.out
-#SBATCH --error=logs/eval_lin_probe-%j.err
+#SBATCH --job-name=lin_prob_ijepa 
+#SBATCH --output=logs/lin_prob_ijepa-%j.out
+#SBATCH --error=logs/lin_prob_ijepa-%j.err
 
 #SBATCH --container-image ghcr.io\#kutayeroglu/ijepa
 #SBATCH --container-mounts /stratch/dataset:/datasets
 #SBATCH --gpus=1
 #SBATCH --cpus-per-gpu=8
 #SBATCH --mem-per-gpu=40G
-#SBATCH --time=05:00:00
+#SBATCH --time=5-05:00:00
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
@@ -19,19 +19,19 @@ echo "Running on host: $(hostname)"
 echo "Allocated GPUs: $SLURM_GPUS_ON_NODE"
 echo ""
 
-echo "--- Checking GPU with nvidia-smi ---"
-nvidia-smi
-echo ""
-
 echo "--- Executing main script ---"
 
 # Set the base dataset directory (inside container, data is mounted at /datasets)
 DATA_DIR="/datasets/imagenet-object-localization-challenge/ILSVRC/Data/CLS-LOC"
 VAL_DATA_DIR="/users/kutay.eroglu/datasets/imagenet/val"
+MODEL_PATH="/users/kutay.eroglu/logs/ijepa/pretraining/jepa-ep300.pth.tar"
 # The code expects DATASET_DIR/in1k structure, so pass the parent directory
 python3 "$HOME/projects/ijepa/main_linprobe.py" \
     --dataset_dir "$DATA_DIR" \
     --val_dir "$VAL_DATA_DIR" \
+    --model_path "$MODEL_PATH" \
+    --batch_size 128 \
+    --learning_rate 0.001 \
     ${EXTRA_ARGS}
 
 echo "--- Job Finished Successfully ---"

--- a/main_linprobe.py
+++ b/main_linprobe.py
@@ -94,14 +94,23 @@ if __name__ == "__main__":
         default=None,
         help="Path to ground truth labels file for flat validation structure (default: None)",
     )
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default=None,
+        help="Path to checkpoint file (default: uses pretrained_models/IN1K-vit.h.14-300e.pth.tar)",
+    )
 
     args = parser.parse_args()
 
     # Params
     script_dir = os.path.dirname(__file__)
-    model_dir = os.path.join(script_dir, "pretrained_models")
-    model_file_name = "IN1K-vit.h.14-300e.pth.tar"
-    model_path = os.path.join(model_dir, model_file_name)
+    if args.model_path:
+        model_path = os.path.expanduser(args.model_path)
+    else:
+        model_dir = os.path.join(script_dir, "pretrained_models")
+        model_file_name = "IN1K-vit.h.14-300e.pth.tar"
+        model_path = os.path.join(model_dir, model_file_name)
 
     dataset_dir = os.path.expanduser(args.dataset_dir)
     val_dir = os.path.expanduser(args.val_dir) if args.val_dir else None
@@ -121,6 +130,7 @@ if __name__ == "__main__":
         logger.info(f"Loaded model successfully from: {model_path}")
     except Exception as e:
         logger.exception(f"Error loading the model from {model_path}: {e}")
+        raise
 
     # NOTE: which one to use from checkpoint: encoder or target_encoder?? why?
     encoder = checkpoint["target_encoder"]


### PR DESCRIPTION
- Introduced a new command-line argument `--model_path` in `main_linprobe.py` to allow users to specify a custom model checkpoint path.
- Updated the logic to load the model from the specified path or fallback to the default pretrained model.
- Modified the SLURM script `run_linprobe.sh` to include the new `--model_path` argument for executing the main script with a specific model checkpoint.